### PR TITLE
phpコンテナにcomposerをインストール

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,4 +1,8 @@
+FROM composer:latest AS composer
+
 FROM php:8.2-fpm
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 COPY php.ini /usr/local/etc/php
 


### PR DESCRIPTION
## 変更内容

- `docker/php/Dockerfile` にcomposerのインストールを追加
- 公式の `composer:latest` imageからマルチステージビルドでバイナリをコピーする方式を採用

## 動作確認

コンテナリビルド後、以下で確認できます：

```bash
docker compose down && docker compose up -d --build --remove-orphans
docker compose exec php composer --version
```

Close #10